### PR TITLE
fix:如果数据库中并未存在要查询的数据则返回空list而不是报错中断

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@
 |database.name|名称|是|influxdb|
 |database.host|地址|是|localhost|
 |database.port|端口|是|8086|
-|database.database|实例|是|vnpy|
-|database.user|用户名|是|root|
-|database.password|密码|是|12345678|
+|database.database|Bucket|是|vnpy|
+|database.user|Organization|是|root|
+|database.password|API Token|是|12345678|

--- a/vnpy_influxdb/influxdb_database.py
+++ b/vnpy_influxdb/influxdb_database.py
@@ -284,7 +284,10 @@ class InfluxdbDatabase(BaseDatabase):
 
         result = self.query_api.query_raw(query)
 
-        df: pd.DataFrame = pd.read_csv(result)[3:]
+        try:
+            df: pd.DataFrame = pd.read_csv(result)[3:]
+        except pd.errors.EmptyDataError:
+            return []
 
         df["date_time"] = pd.to_datetime(df["dateTime:RFC3339.2"])
 


### PR DESCRIPTION
由于回测策略时由于读取数据是将时段切割开读取的，很容易查询不到数据而报错退出。